### PR TITLE
Fix cmus segfault on ppc64

### DIFF
--- a/srcpkgs/cmus/patches/ppc64fix.patch
+++ b/srcpkgs/cmus/patches/ppc64fix.patch
@@ -1,0 +1,122 @@
+diff --git a/format_print.c b/format_print.c
+index 0fee984..c7c0ef7 100644
+--- format_print.c
++++ format_print.c
+@@ -216,7 +216,8 @@ static void print_str(const char *src)
+ 
+ 		}
+ 	} else {
+-		int s = 0, d = 0;
++		int s = 0;
++		size_t d = 0;
+ 		uchar u;
+ 
+ 		while (1) {
+@@ -471,7 +472,7 @@ static void format_parse(int str_width, const char *format, const struct format_
+ 		u = u_get_char(format, &s);
+ 		if (u != '%') {
+ 			gbuf_grow(str, 4);
+-			u_set_char(str->buffer, (int *)&str->len, u);
++			u_set_char(str->buffer, &str->len, u);
+ 			(*len) += u_char_width(u);
+ 			continue;
+ 		}
+@@ -594,7 +595,7 @@ static void format_write(char *buf, int str_width)
+ 		strcpy(buf + pos + ws_len, r_str.buffer);
+ 	} else {
+ 		int l_space = str_width - str_len.rlen;
+-		int pos = 0;
++		size_t pos = 0;
+ 		int idx = 0;
+ 
+ 		if (l_space > 0)
+diff --git a/id3.c b/id3.c
+index d505ba9..d5947b9 100644
+--- id3.c
++++ id3.c
+@@ -287,10 +287,10 @@ static int utf16_is_special(uchar uch)
+ 	return utf16_is_hsurrogate(uch) || utf16_is_lsurrogate(uch) || utf16_is_bom(uch);
+ }
+ 
+-static char *utf16_to_utf8(const unsigned char *buf, int buf_size)
++static char *utf16_to_utf8(const unsigned char *buf, size_t buf_size)
+ {
+ 	char *out;
+-	int i, idx;
++	size_t i, idx;
+ 	int little_endian = 0;
+ 
+ 	if (buf_size < 2)
+diff --git a/uchar.c b/uchar.c
+index 7b8691a..36509d7 100644
+--- uchar.c
++++ uchar.c
+@@ -428,7 +428,7 @@ void u_set_char_raw(char *str, int *idx, uchar uch)
+  * Printing functions, these lose information
+  */
+ 
+-void u_set_char(char *str, int *idx, uchar uch)
++void u_set_char(char *str, size_t *idx, uchar uch)
+ {
+ 	int i = *idx;
+ 
+@@ -476,10 +476,11 @@ invalid:
+ 	}
+ }
+ 
+-int u_copy_chars(char *dst, const char *src, int *width)
++size_t u_copy_chars(char *dst, const char *src, int *width)
+ {
+ 	int w = *width;
+-	int si = 0, di = 0;
++	int si = 0;
++	size_t di = 0;
+ 	int cw;
+ 	uchar u;
+ 
+diff --git a/uchar.h b/uchar.h
+index 237cd55..8e03162 100644
+--- uchar.h
++++ uchar.h
+@@ -137,7 +137,7 @@ uchar u_get_char(const char *str, int *idx);
+  * @uch  unicode character
+  */
+ void u_set_char_raw(char *str, int *idx, uchar uch);
+-void u_set_char(char *str, int *idx, uchar uch);
++void u_set_char(char *str, size_t *idx, uchar uch);
+ 
+ /*
+  * @dst    destination buffer
+@@ -150,7 +150,7 @@ void u_set_char(char *str, int *idx, uchar uch);
+  *
+  * Returns number of _bytes_ copied.
+  */
+-int u_copy_chars(char *dst, const char *src, int *width);
++size_t u_copy_chars(char *dst, const char *src, int *width);
+ 
+ /*
+  * @dst    destination buffer
+diff --git a/ui_curses.c b/ui_curses.c
+index 564b205..9621d94 100644
+--- ui_curses.c
++++ ui_curses.c
+@@ -467,7 +467,8 @@ static void dump_print_buffer(int row, int col)
+  */
+ static int format_str(char *buf, const char *str, int width)
+ {
+-	int s = 0, d = 0, ellipsis_pos = 0, cut_double_width = 0;
++	int s = 0, ellipsis_pos = 0, cut_double_width = 0;
++	size_t d = 0;
+ 
+ 	while (1) {
+ 		uchar u;
+@@ -1237,7 +1238,8 @@ static void dump_buffer(const char *buffer)
+ static void do_update_commandline(void)
+ {
+ 	char *str;
+-	int w, idx;
++	int w;
++	size_t idx;
+ 	char ch;
+ 
+ 	move(LINES - 1, 0);


### PR DESCRIPTION
The segfault was caused by a narrowing cast in a call to u_set_char().

See https://github.com/cmus/cmus/pull/941 for the fix submitted to upstream.