### PR TITLE
Add missing dependency for cinnamon-settings.

### DIFF
--- a/srcpkgs/cinnamon/template
+++ b/srcpkgs/cinnamon/template
@@ -20,7 +20,7 @@ depends="accountsservice libcaribou cinnamon-settings-daemon>=${version%.*}
  gnome-themes-standard gnome-themes-standard-metacity gnome-backgrounds
  network-manager-applet polkit-gnome upower>=0.99.7 libkeybinder3 python3-dbus
  python3-gobject python3-pam python3-pexpect python3-Pillow python3-inotify
- python3-tinycss python3-pytz libtimezonemap"
+ python3-tinycss python3-pytz python3-distro libtimezonemap"
 short_desc="GNOME3 fork of Linux Mint with GNOME2 aspect"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-2.0-or-later, LGPL-2.0-or-later"


### PR DESCRIPTION
The `distro` Python module is imported from here:
```python
/usr/share/cinnamon/cinnamon-settings/modules/cs_info.py
10:import distro
107:        s = '%s (%s)' % (' '.join(distro.linux_distribution()), arch)
```
It was working before, maybe older versions did not use this module.
I built the package with `./xbps-src -j16 pkg cinnamon`,  installed it over the standard one with `xbps-install --force --repository=hostdir/binpkgs cinnamon`, and now it works again.